### PR TITLE
x64 Support (also fixed program hanging if an Invalid GUID is passed to Init)

### DIFF
--- a/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPI.NET.csproj
+++ b/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPI.NET.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPI.cs
+++ b/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPI.cs
@@ -23,16 +23,21 @@ namespace Razer.Chroma.Broadcast
             var b = (uint)((i >> 64) & 0xFFFFFFFF);
             var c = (uint)((i >> 32) & 0xFFFFFFFF);
             var d = (uint)((i >> 0) & 0xFFFFFFFF);
-
-            var initResult = RzChromaBroadcastAPINative.Init(a, b, c, d);
-
-            if (initResult == RzResult.SUCCESS)
+            try
             {
-                notificationCallback = new RzChromaBroadcastAPINative.RegisterEventNotificationCallback(EventNotificationCallback);
-                initResult = RzChromaBroadcastAPINative.RegisterEventNotification(notificationCallback);
-            }
+                var initResult = RzChromaBroadcastAPINative.Init(a, b, c, d);
 
-            return initResult;
+                if (initResult == RzResult.SUCCESS)
+                {
+                    notificationCallback = new RzChromaBroadcastAPINative.RegisterEventNotificationCallback(EventNotificationCallback);
+                    initResult = RzChromaBroadcastAPINative.RegisterEventNotification(notificationCallback);
+                }
+
+                return initResult;
+            } catch (SEHException e)
+			{
+                return RzResult.FAILED;
+            }
         }
 
         public RzResult UnInit()

--- a/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPINative.cs
+++ b/RzChromaBroadcastAPI.NET/RzChromaBroadcastAPINative.cs
@@ -1,23 +1,94 @@
 ﻿using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Razer.Chroma.Broadcast
 {
-    internal class RzChromaBroadcastAPINative
-    {
-        [DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern RzResult Init(uint a, uint b, uint c, uint d);
 
-        [DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern RzResult UnInit();
+	#region Implementation
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate int RegisterEventNotificationCallback(int message, IntPtr data);
+	/// <summary>
+	/// Base Interface for both 32 bit and 64 bit
+	/// </summary>
+	internal interface IRzChromaBroadcastAPINative
+	{
+		RzResult Init(uint a, uint b, uint c, uint d);
 
-        [DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern RzResult RegisterEventNotification(RegisterEventNotificationCallback callback);
+		RzResult UnInit();
+		RzResult RegisterEventNotification(RzChromaBroadcastAPINative.RegisterEventNotificationCallback callback);
+		RzResult UnRegisterEventNotification();
+	}
 
-        [DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern RzResult UnRegisterEventNotification();
-    }
+	/// <summary>
+	/// 32 Bit Implementation
+	/// </summary>
+	internal class RzChromaBroadcastAPINative32 : IRzChromaBroadcastAPINative
+	{
+		RzResult IRzChromaBroadcastAPINative.Init(uint a, uint b, uint c, uint d) => Init(a, b, c, d);
+
+		RzResult IRzChromaBroadcastAPINative.RegisterEventNotification(RzChromaBroadcastAPINative.RegisterEventNotificationCallback callback) => RegisterEventNotification(callback);
+
+		RzResult IRzChromaBroadcastAPINative.UnInit() => UnInit();
+
+		RzResult IRzChromaBroadcastAPINative.UnRegisterEventNotification() => UnRegisterEventNotification();
+
+
+		[DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
+		public static extern RzResult Init(uint a, uint b, uint c, uint d); // TODO: If we decide to pass the GUID directly this should just take in (Guid guid)
+
+		[DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
+		public static extern RzResult UnInit();
+
+		[DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
+		public static extern RzResult RegisterEventNotification(RzChromaBroadcastAPINative.RegisterEventNotificationCallback callback);
+
+		[DllImport("RzChromaBroadcastAPI.dll", CallingConvention = CallingConvention.Cdecl)]
+		public static extern RzResult UnRegisterEventNotification();
+	}
+
+	/// <summary>
+	/// 64 Bit Implementation
+	/// </summary>
+	internal class RzChromaBroadcastAPINative64 : IRzChromaBroadcastAPINative
+	{
+		RzResult IRzChromaBroadcastAPINative.Init(uint a, uint b, uint c, uint d) => Init(new uint[] { a, b, c, d });
+
+		RzResult IRzChromaBroadcastAPINative.RegisterEventNotification(RzChromaBroadcastAPINative.RegisterEventNotificationCallback callback) => RegisterEventNotification(callback);
+
+		RzResult IRzChromaBroadcastAPINative.UnInit() => UnInit();
+
+		RzResult IRzChromaBroadcastAPINative.UnRegisterEventNotification() => UnRegisterEventNotification();
+
+		// No need to specify native calling conventions on x86_64 as it is always fastcall even if otherwise specified
+
+		[DllImport("RzChromaBroadcastAPI64.dll")]
+		public static extern RzResult Init(uint[] guid); // 64-bit version expects a Guid* not a Guid // TODO: If we decide to pass the GUID directly this should just take in (in Guid guid)
+
+		[DllImport("RzChromaBroadcastAPI64.dll")]
+		public static extern RzResult UnInit();
+
+		[DllImport("RzChromaBroadcastAPI64.dll")]
+		public static extern RzResult RegisterEventNotification(RzChromaBroadcastAPINative.RegisterEventNotificationCallback callback);
+
+		[DllImport("RzChromaBroadcastAPI64.dll")]
+		public static extern RzResult UnRegisterEventNotification();
+	}
+	#endregion
+
+	internal class RzChromaBroadcastAPINative
+	{
+		// On x86_64 the calling convention is always fastcall even if otherwise specified, so it's fine to use cdecl here.
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate int RegisterEventNotificationCallback(int message, IntPtr data);
+
+		// Get the native api for the right architecture.
+		private static readonly IRzChromaBroadcastAPINative _native = IntPtr.Size == 8 ? (IRzChromaBroadcastAPINative)new RzChromaBroadcastAPINative64() : new RzChromaBroadcastAPINative32();
+
+		// Pass all calls to the appropriate Native class for this architecture.
+
+		public static RzResult Init(uint a, uint b, uint c, uint d) => _native.Init(a, b, c, d);
+		public static RzResult UnInit() => _native.UnInit();
+		public static RzResult RegisterEventNotification(RegisterEventNotificationCallback callback) => _native.RegisterEventNotification(callback);
+		public static RzResult UnRegisterEventNotification() => _native.UnRegisterEventNotification();
+	}
 }


### PR DESCRIPTION
I've added x64 support and I've also fixed a nasty bug where the program would hang if you passed an invalid GUID to Init.

I also fixed the fact that you are flipping the GUID as I couldn't see why this was being done, however I have not included that commit in this pull request as anybody using this library would have to flip their GUIDs back to the original state. If you are interested in that, take a look at my fork's flip_fix branch. I will do a PR for that if requested.